### PR TITLE
Listen for UI on 9702

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -27,6 +27,9 @@ spec:
     - name: https
       port: 443
       targetPort: https
+    - name: ui-forward
+      port: 9702
+      targetPort: https
     - name: grpc
       port: 9701
       targetPort: grpc


### PR DESCRIPTION
Port 9702 is hard-coded into `waypoint ui -authenticate`, so we'd better listen on it.