### PR TITLE
Add GitHub community files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+HashiCorp Community Guidelines apply to you when interacting with the community here on GitHub and contributing code.
+
+Please read the full text at https://www.hashicorp.com/community-guidelines

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,8 +60,8 @@ issue. Stale issues will be closed.
 1. Unless it is critical, the issue is left for a period of time (sometimes many
    weeks or months), giving outside contributors a chance to address the issue
    and our internal teams time to plan for inclusion in a release.
-1. Once someone commits to addressing the issue, it is put in the target milestone
-   (e.g. `0.5.x`) and assigned to the person who has committed to the work.
+1. Once someone commits to addressing the issue, it is assigned to a Waypoint maintainer
+   or community member who has committed to the work.
    1. If you'd like to work on an open issue, please double-check first that no
    one else is currently working on it.
    1. It's also best to give a quick overview of how you plan to solve the issue
@@ -75,13 +75,10 @@ issue. Stale issues will be closed.
 ## Opening a PR
 
 1. Title the PR with a helpful prefix following the pattern `parent/child`, 
-e.g. `builtin/k8s` or `internal/core`
+e.g. `service/ui` or `bootstrap/job`
 1. Include helpful information in the description
    * For a bug fix, explain or show an example of the behavior before and 
   after the change
    * If applicable, include information on how to test manually
 1. Request review from either `waypoint-core` or `waypoint-frontend` based on 
 your changes
-
->Note: the auto-labeler will assign other labels after you open the PR, based 
->on what files have changes.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to Waypoint Helm
+
+>**Note:** We take Waypoint's security and our users' trust very seriously.
+>If you believe you have found a security issue in Waypoint, please responsibly
+>disclose by contacting us at security@hashicorp.com.
+
+**First:** if you're unsure or afraid of _anything_, just ask or submit the
+issue or pull request anyways. You won't be yelled at for giving your best
+effort. The worst that can happen is that you'll be politely asked to change
+something. We appreciate any sort of contributions, and don't want a wall of
+rules to get in the way of that.
+
+That said, if you want to ensure that a pull request is likely to be merged,
+talk to us! A great way to do this is in issues themselves. When you want to
+work on an issue, comment on it first and tell us the approach you want to take.
+
+## Getting Started
+
+### Some Ways to Contribute
+
+* Report potential bugs.
+* Suggest product enhancements.
+* Increase our test coverage.
+* Fix a [bug](https://github.com/hashicorp/waypoint-helm/labels/bug).
+* Implement a requested [enhancement](https://github.com/hashicorp/waypoint-helm/labels/enhancement).
+* Improve our guides and documentation.
+
+### Reporting an Issue:
+
+>Note: Issues on GitHub for Waypoint are intended to be related to bugs or feature requests.
+>Questions should be directed to other community resources such as the [forum](https://discuss.hashicorp.com/)
+
+* Make sure you test against the latest released version. It is possible we
+already fixed the bug you're experiencing. However, if you are on an older
+version of Waypoint and feel the issue is critical, do let us know.
+
+* Check existing issues (both open and closed) to make sure it has not been
+reported previously.
+
+* Provide a reproducible test case. If a contributor can't reproduce an issue,
+then it dramatically lowers the chances it'll get fixed. If we can't reproduce
+an issue long enough, we are usually forced to close the issue.
+
+* As part of the test case, please include any Waypoint configurations
+(`waypoint.hcl`), build configs such as Dockerfiles, etc. Log output with
+log level set with verbose flags (at least `-vv`) is helpful too.
+
+* If the issue is related to the browser UI, please also include the name 
+and version of the browser and any extensions that may be interacting 
+with the UI
+
+* Aim to respond promptly to any questions made by the Waypoint team on your
+issue. Stale issues will be closed.
+
+### Issue Lifecycle
+
+1. The issue is reported.
+1. The issue is verified and categorized by a Waypoint maintainer.
+   Categorization is done via tags. For example, bugs are tagged as "bug".
+1. Unless it is critical, the issue is left for a period of time (sometimes many
+   weeks or months), giving outside contributors a chance to address the issue
+   and our internal teams time to plan for inclusion in a release.
+1. Once someone commits to addressing the issue, it is put in the target milestone
+   (e.g. `0.5.x`) and assigned to the person who has committed to the work.
+   1. If you'd like to work on an open issue, please double-check first that no
+   one else is currently working on it.
+   1. It's also best to give a quick overview of how you plan to solve the issue
+   in a comment. That way people have a chance to inform you of any potential
+   hurdles or unknown complications you may run into.
+1. The issue is addressed in a pull request or commit. The issue will be
+   referenced in the commit message so that the code that fixes it is clearly
+   linked.
+1. The issue is closed.
+
+## Opening a PR
+
+1. Title the PR with a helpful prefix following the pattern `parent/child`, 
+e.g. `builtin/k8s` or `internal/core`
+1. Include helpful information in the description
+   * For a bug fix, explain or show an example of the behavior before and 
+  after the change
+   * If applicable, include information on how to test manually
+1. Request review from either `waypoint-core` or `waypoint-frontend` based on 
+your changes
+
+>Note: the auto-labeler will assign other labels after you open the PR, based 
+>on what files have changes.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Let us know about a bug!
+title: ''
+labels: new
+assignees: ''
+
+---
+
+<!-- Please reserve GitHub issues for bug reports and feature requests.
+
+For questions, the best place to get answers is on our [discussion forum](https://discuss.hashicorp.com/c/waypoint), as they will get more visibility from experienced users than the issue tracker.
+
+Please note: We take Waypoint's security and our users' trust very seriously. If you believe you have found a security issue in Waypoint, please responsibly disclose by contacting us at security@hashicorp.com. Our PGP key is available at our security page: https://www.hashicorp.com/security/
+
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps to Reproduce**
+Steps to reproduce the behavior.
+
+Please include any `waypoint.hcl` files if applicable, as well as a
+[GitHub Gist](https://gist.github.com/) of any relevant logs or steps to
+reproduce the bug. Running `waypoint` commands with `-v` up to `-vvv` will
+include any additional debugging info in the log.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Waypoint Platform Versions**
+Additional version and platform information to help triage the issue if
+applicable:
+
+* Helm CLI Version:
+* Kubernetes Version:
+* Waypoint CLI Version:
+* Waypoint Server Platform and Version: (like `docker`, `nomad`, `kubernetes`)
+* Waypoint Plugin: (like `aws/ecs`, `pack`, `azure`)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Ask a question
+    url: https://discuss.hashicorp.com/c/waypoint
+    about: For increased visibility, please post questions on the discussion forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest something!
+title: ''
+labels: new
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Explain any additional use-cases**
+If there are any use-cases that would help us understand the use/need/value please share them as they can help us decide on acceptance and prioritization.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This pull request adds the HashiCorp code of conduct, as well as the general GitHub files for a public repo like bug/feature template issue requests and how to contribute.