### PR TITLE
Allow configuration of server run flags.

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -70,6 +70,9 @@ spec:
           - "-tls-cert-file=/secret/certs/{{ .Values.server.certs.certName }}"
           - "-tls-key-file=/secret/certs/{{ .Values.server.certs.keyName }}"
           {{- end }}
+          {{- range .Values.server.runArgs }}
+          - "{{ . }}"
+          {{- end }}
           env:
             - name: HOME
               value: /home/waypoint

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,9 @@ server:
     # tag: "latest"
     # pullPolicy: Always
 
+  # Arguments to pass to the `waypoint server run` command. Will overwrite default options.
+  runArgs: []
+
   certs:
     # The name of the Kubernetes secret of type "kubernetes.io/tls" that
     # contains the TLS certificate and key to use for the server API.


### PR DESCRIPTION
This also allows the customization of the default arguments - though both the default and user-specified values will exist, the last-write wins, so the custom values take precedence.

Fixes https://github.com/hashicorp/waypoint-helm/issues/7

### How to verify

Run `helm install waypoint ./ --set server.runArgs={-url-enabled=false}`, and observe that the `-url-enabled=false` arg is passed to the waypoint server in the stateful set manifest.