### PR TITLE
Allow waypoint to deploy into namespaces other than its own

### DIFF
--- a/templates/runner-odr-clusterrolebinding.yaml
+++ b/templates/runner-odr-clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if (eq (.Values.runner.serviceAccount.create | toString) "true" ) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "waypoint.fullname" . }}-runner-odr-rolebinding-custom
+  labels:
+    app.kubernetes.io/name: {{ include "waypoint.name" . }}-runner
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: ""
+  kind: ClusterRole
+  name: {{ template "waypoint.fullname" . }}-runner-odr
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "waypoint.runner.odr.serviceAccount.name" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/runner-odr-rolebinding.yaml
+++ b/templates/runner-odr-rolebinding.yaml
@@ -1,35 +1,33 @@
 {{- if (eq (.Values.runner.serviceAccount.create | toString) "true" ) }}
+
+{{/* If no managedNamespaces are provided, default to the release namespace */}}
+{{ $managedNamespaces := list  }}
+{{- range .Values.runner.odr.managedNamespaces }}
+  {{ $managedNamespaces = append $managedNamespaces . }}
+{{- end -}}
+{{- if eq (len $managedNamespaces) 0 -}}
+  {{ $managedNamespaces = append $managedNamespaces .Release.Namespace }}
+{{- end -}}
+
+{{- range $managedNamespaces }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "waypoint.fullname" . }}-runner-odr-rolebinding-edit
+  name: {{ template "waypoint.fullname" $ }}-runner-odr-rolebinding-edit
+  namespace: {{ . }}
   labels:
-    app.kubernetes.io/name: {{ include "waypoint.name" . }}-runner
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "waypoint.name" $ }}-runner
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
 roleRef:
   apiGroup: ""
   kind: ClusterRole
   name: edit
 subjects:
   - kind: ServiceAccount
-    name: {{ template "waypoint.runner.odr.serviceAccount.name" . }}
-    namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ template "waypoint.fullname" . }}-runner-odr-rolebinding-custom
-  labels:
-    app.kubernetes.io/name: {{ include "waypoint.name" . }}-runner
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-roleRef:
-  apiGroup: ""
-  kind: ClusterRole
-  name: {{ template "waypoint.fullname" . }}-runner-odr
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "waypoint.runner.odr.serviceAccount.name" . }}
-    namespace: {{ .Release.Namespace }}
+    name: {{ template "waypoint.runner.odr.serviceAccount.name" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -112,6 +112,12 @@ runner:
       # tag: "latest"
       # pullPolicy: Always
 
+    # List of namespaces that waypoint can access and deploy into.
+    # By default, the waypoint on-demand runner will create a rolebinding granting the
+    # edit clusterrole in the namespace the chart is installed into. Waypoint will
+    # instead create this rolebinding in each managed namespace.
+    managedNamespaces: []
+
     # Definition of the serviceAccount used to by Waypoint on-demand runners.
     # On-demand runners execute the kubernetes plugin, so they need permission to
     # and destroy deployments, services, etc.

--- a/values.yaml
+++ b/values.yaml
@@ -113,9 +113,13 @@ runner:
       # pullPolicy: Always
 
     # List of namespaces that waypoint can access and deploy into.
-    # By default, the waypoint on-demand runner will create a rolebinding granting the
-    # edit clusterrole in the namespace the chart is installed into. Waypoint will
-    # instead create this rolebinding in each managed namespace.
+    # By default, the Waypoint on-demand runner will create a rolebinding granting the
+    # edit clusterrole in the namespace the chart is installed into.
+    # If any managedNamespaces are specified, rolebindings will be created to
+    # grant permissions in those namespaces instead.
+    # If Waypoint should be able to generate deployments in it's own namespace and
+    # additional other namespaces, Waypoint's own namespace must also be appended to
+    # this set.
     managedNamespaces: []
 
     # Definition of the serviceAccount used to by Waypoint on-demand runners.


### PR DESCRIPTION
Prior to this, the waypoint on-demand runners were granted the `edit` role on the namespace the chart was installed into. This made made it impossible for runners to deploy into other namespaces.

As a concrete example, I'm trying to install waypoint into a `waypoint` namespace, and have it deploy into `dev` and `prod` namespaces.

This change adds a `managedNamespaces` field, and creates a rolebinding in each managed namespace to allow the on-demand runner to access its resources.

### How to verify this change

- Create a kubernetes cluster with `waypoint`, `dev`, and `prod` namespaces
- Create the following values file:
```
runner:
  odr:
    managedNamespaces:
    - dev
    - prod
```
- Install the helm chart into the `waypoint` namespace, i.e.: `helm install --values=<values-file> waypoint ./ --namespace waypoint`
- Create a waypoint app that deploys into the `dev` [namespace](https://www.waypointproject.io/plugins/kubernetes#namespace) (or switches namespaces based on the workspace)
- Add a git repo and auth to your project to enable the on-demand runners
- Trigger a remote build and deploy, and observe as the on-demand runner can create a deployment in the `dev` namespace, while running in the `waypoint` namespace

