### PR TITLE
Customize runner flags, move log flags to defaults.

### DIFF
--- a/templates/runner-deployment.yaml
+++ b/templates/runner-deployment.yaml
@@ -71,8 +71,10 @@ spec:
           args:
           - "runner"
           - "agent"
-          - "-vvv"
           - "-liveness-tcp-addr=:1234"
+          {{- range .Values.runner.agentArgs }}
+          - "{{ . }}"
+          {{- end }}
           env:
             - name: HOME
               value: /home/waypoint

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -61,7 +61,6 @@ spec:
           - "server"
           - "run"
           - "-accept-tos"
-          - "-vv"
           - "-db=/data/data.db"
           - "-listen-grpc=0.0.0.0:9701"
           - "-listen-http=0.0.0.0:9702"

--- a/values.yaml
+++ b/values.yaml
@@ -17,7 +17,7 @@ server:
     # pullPolicy: Always
 
   # Arguments to pass to the `waypoint server run` command. Will overwrite default options.
-  runArgs: []
+  runArgs: ["-vv"]
 
   certs:
     # The name of the Kubernetes secret of type "kubernetes.io/tls" that
@@ -102,6 +102,9 @@ runner:
     pullPolicy: IfNotPresent
     # tag: "latest"
     # pullPolicy: Always
+
+  # Arguments to pass to the `waypoint runner agent` command. Will overwrite default options.
+  agentArgs: ["-vvv"]
 
   odr:
     # The image to use for the on-demand runner.


### PR DESCRIPTION
This change allows the user to customize flags provided to `waypoint runner agent`, with the most obvious use-case being customizing the log level.

This also moves the log flags out of the template files and into the default values. With the flags where they were, it wasn't possible to reduce the log level to `warn`. The downside of doing this is that when users add their own runArgs, they will need to respecify the log flag, or it will be omitted, and as a result more people will probably be running on `warn` level.

Related to https://github.com/hashicorp/waypoint-helm/issues/16