### PR TITLE
Runner-only install, supports adoption

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,4 +1,4 @@
-
+{{- if (eq (.Values.server.enabled | toString) "true") }}
 Thank you for installing HashiCorp Waypoint!
 
 Waypoint will take a few minutes to bootstrap. Once it is bootstrapped, you
@@ -13,4 +13,16 @@ Alternately, you can visit the address of the load balancer service configured.
 If anything fails to configure properly you can uninstall this release:
 
   $ helm uninstall {{ .Release.Name }}
+{{- else }}
+{{- if (eq (.Values.runner.enabled | toString) "true") }}
+You've successfully installed a HashiCorp Waypoint runner!
 
+The runner should start in a few minutes. You can look for the runner to register
+with the server using the "waypoint runner list" command. If you did not supply
+a runner token ahead of time, you may have to adopt the runner using the
+UI or the "waypoint runner adopt" command.
+
+If the runner does not show up in the runner list output, you can debug it
+by looking at the logs for the runner pod that was just launched.
+{{- end }}
+{{- end }}

--- a/templates/bootstrap-role.yaml
+++ b/templates/bootstrap-role.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.bootstrap.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.server.enabled | toString) "true") (eq (.Values.bootstrap.serviceAccount.create | toString) "true" )) }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/templates/bootstrap-rolebinding.yaml
+++ b/templates/bootstrap-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.bootstrap.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.server.enabled | toString) "true") (eq (.Values.bootstrap.serviceAccount.create | toString) "true" )) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/templates/bootstrap-serviceaccount.yaml
+++ b/templates/bootstrap-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.bootstrap.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.server.enabled | toString) "true") (eq (.Values.bootstrap.serviceAccount.create | toString) "true" )) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/runner-deployment.yaml
+++ b/templates/runner-deployment.yaml
@@ -41,10 +41,13 @@ spec:
       volumes:
         - name: home
           emptyDir: {}
+      {{- if .Values.server.enabled }}
         - name: token
           secret:
             secretName: {{ template "waypoint.runnerTokenSecret" . }}
+      {{- end }}
       {{- include "imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.server.enabled }}
       initContainers:
       - name: wait-for-token
         image: "busybox"
@@ -60,6 +63,7 @@ spec:
           - name: token
             mountPath: /secret
             readOnly: true
+      {{- end }}
       containers:
         - name: waypoint
           resources:
@@ -72,23 +76,37 @@ spec:
           - "runner"
           - "agent"
           - "-liveness-tcp-addr=:1234"
+          {{- if (and .Values.runner.server.addr .Values.runner.server.cookie) }}
+          - "-cookie={{ .Values.runner.server.cookie }}"
+          {{- end }}
           {{- range .Values.runner.agentArgs }}
           - "{{ . }}"
           {{- end }}
           env:
             - name: HOME
               value: /home/waypoint
+            {{- if .Values.runner.server.addr }}
+            - name: WAYPOINT_SERVER_ADDR
+              value: {{ .Values.runner.server.addr }}
+            - name: WAYPOINT_SERVER_TLS
+              value: {{ .Values.runner.server.tls | toString }}
+            - name: WAYPOINT_SERVER_TLS_SKIP_VERIFY
+              value: {{ .Values.runner.server.tlsSkipVerify | toString }}
+            {{- else }}
             - name: WAYPOINT_SERVER_ADDR
               value: {{ template "waypoint.fullname" . }}-server:9701
             - name: WAYPOINT_SERVER_TLS
               value: "true"
             - name: WAYPOINT_SERVER_TLS_SKIP_VERIFY
               value: "true"
+            {{- end }}
+            {{- if .Values.server.enabled }}
             - name: WAYPOINT_SERVER_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ template "waypoint.runnerTokenSecret" . }}
                   key: token
+            {{- end }}
           volumeMounts:
             - name: home
               mountPath: /home/waypoint

--- a/templates/runner-deployment.yaml
+++ b/templates/runner-deployment.yaml
@@ -103,9 +103,9 @@ spec:
             - name: WAYPOINT_SERVER_ADDR
               value: {{ .Values.runner.server.addr }}
             - name: WAYPOINT_SERVER_TLS
-              value: {{ .Values.runner.server.tls | toString }}
+              value: "{{ .Values.runner.server.tls | toString }}"
             - name: WAYPOINT_SERVER_TLS_SKIP_VERIFY
-              value: {{ .Values.runner.server.tlsSkipVerify | toString }}
+              value: "{{ .Values.runner.server.tlsSkipVerify | toString }}"
             {{- else }}
             - name: WAYPOINT_SERVER_ADDR
               value: {{ template "waypoint.fullname" . }}-server:9701

--- a/templates/runner-deployment.yaml
+++ b/templates/runner-deployment.yaml
@@ -1,7 +1,7 @@
 {{- if (eq (.Values.runner.enabled | toString) "true") }}
-# Deployment to run the Waypoint static runner.
+# StatefulSet to run the Waypoint static runner.
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "waypoint.fullname" . }}-runner
   namespace: {{ .Release.Namespace }}
@@ -11,12 +11,25 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- template "waypoint.statefulSet.annotations" . }}
 spec:
+  serviceName: {{ template "waypoint.fullname" . }}-runner
   replicas: 1 # We only want 1 static runner
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "waypoint.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       component: runner
+  volumeClaimTemplates:
+    - metadata:
+        name: data-{{ .Release.Namespace }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.runner.storage.size }}
+        {{- if .Values.runner.storage.storageClass }}
+        storageClassName: {{ .Values.runner.storage.storageClass }}
+        {{- end }}
   template:
     metadata:
       labels:
@@ -76,6 +89,7 @@ spec:
           - "runner"
           - "agent"
           - "-liveness-tcp-addr=:1234"
+          - "-state-dir=/data/runner"
           {{- if (and .Values.runner.server.addr .Values.runner.server.cookie) }}
           - "-cookie={{ .Values.runner.server.cookie }}"
           {{- end }}
@@ -110,6 +124,8 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home/waypoint
+            - name: data-{{ .Release.Namespace }}
+              mountPath: /data
           livenessProbe:
             tcpSocket:
               port: 1234

--- a/templates/runner-odr-clusterrole.yaml
+++ b/templates/runner-odr-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.runner.odr.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.runner.enabled | toString) "true") (eq (.Values.runner.odr.serviceAccount.create | toString) "true" )) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/templates/runner-odr-clusterrolebinding.yaml
+++ b/templates/runner-odr-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.runner.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.runner.enabled | toString) "true") (eq (.Values.runner.odr.serviceAccount.create | toString) "true" )) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/runner-odr-rolebinding.yaml
+++ b/templates/runner-odr-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.runner.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.runner.enabled | toString) "true") (eq (.Values.runner.odr.serviceAccount.create | toString) "true" )) }}
 
 {{/* If no managedNamespaces are provided, default to the release namespace */}}
 {{ $managedNamespaces := list  }}

--- a/templates/runner-odr-serviceaccount.yaml
+++ b/templates/runner-odr-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.runner.odr.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.runner.enabled | toString) "true") (eq (.Values.runner.odr.serviceAccount.create | toString) "true" )) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/runner-serviceaccount.yaml
+++ b/templates/runner-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.runner.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.runner.enabled | toString) "true") (eq (.Values.runner.serviceAccount.create | toString) "true" )) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/runner-statefulset.yaml
+++ b/templates/runner-statefulset.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- template "waypoint.statefulSet.annotations" . }}
 spec:
   serviceName: {{ template "waypoint.fullname" . }}-runner
-  replicas: 1 # We only want 1 static runner
+  replicas: {{ .Values.runner.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "waypoint.name" . }}

--- a/templates/runner-statefulset.yaml
+++ b/templates/runner-statefulset.yaml
@@ -58,6 +58,10 @@ spec:
         - name: token
           secret:
             secretName: {{ template "waypoint.runnerTokenSecret" . }}
+      {{- else if .Values.runner.server.tokenSecret }}
+        - name: token
+          secret:
+            secretName: {{ .Values.runner.server.tokenSecret }}
       {{- end }}
       {{- include "imagePullSecrets" . | nindent 6 }}
       {{- if .Values.server.enabled }}
@@ -119,6 +123,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "waypoint.runnerTokenSecret" . }}
+                  key: token
+            {{- else if .Values.runner.server.tokenSecret }}
+            - name: WAYPOINT_SERVER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.runner.server.tokenSecret }}
                   key: token
             {{- end }}
           volumeMounts:

--- a/templates/runner-statefulset.yaml
+++ b/templates/runner-statefulset.yaml
@@ -93,9 +93,12 @@ spec:
           - "runner"
           - "agent"
           - "-liveness-tcp-addr=:1234"
-          - "-state-dir=/data/runner"
           {{- if (and .Values.runner.server.addr .Values.runner.server.cookie) }}
           - "-cookie={{ .Values.runner.server.cookie }}"
+          # TODO(mitchellh): this should be outside the if statement once
+          # Waypoint 0.8 is released. We want this set always. For now, we
+          # can just set it during adoption operations.
+          - "-state-dir=/data/runner"
           {{- end }}
           {{- range .Values.runner.agentArgs }}
           - "{{ . }}"

--- a/templates/runner-token-secret.yaml
+++ b/templates/runner-token-secret.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (.Values.server.enabled | toString) "true") }}
 {{- $prev := (lookup "v1" "Secret" .Release.Namespace (include "waypoint.runnerTokenSecret" . )) -}}
 
 apiVersion: v1
@@ -14,4 +15,4 @@ data:
   {{- else }}
   token: ""
   {{- end }}
-
+{{ end }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.ingress.enabled -}}
+{{- if (and (eq (.Values.server.enabled | toString) "true") .Values.ui.ingress.enabled) -}}
 {{- $fullname := (include "waypoint.fullname" .) -}}
 {{- $extraPaths := .Values.ui.ingress.extraPaths -}}
 apiVersion: networking.k8s.io/v1

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if (eq (.Values.server.serviceAccount.create | toString) "true" ) }}
+{{- if (and (eq (.Values.server.enabled | toString) "true") (eq (.Values.server.serviceAccount.create | toString) "true" )) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/templates/server-token-secret.yaml
+++ b/templates/server-token-secret.yaml
@@ -1,3 +1,4 @@
+{{- if (eq (.Values.server.enabled | toString) "true") }}
 {{- $prev := (lookup "v1" "Secret" .Release.Namespace (include "waypoint.serverTokenSecret" . )) -}}
 
 apiVersion: v1
@@ -15,3 +16,4 @@ data:
   token: ""
   {{- end }}
 
+{{ end }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq (.Values.ui.service.enabled | toString) "true" }}
+{{- if (and (eq (.Values.ui.service.enabled | toString) "true") (eq (.Values.server.enabled | toString) "true")) }}
 # UI Service for Waypoint Server
 apiVersion: v1
 kind: Service

--- a/values.yaml
+++ b/values.yaml
@@ -95,6 +95,11 @@ runner:
   # be configured for this cluster.
   enabled: true
 
+  # The number of runners to run. This normally only has to be 1 or 2 since
+  # the way Waypoint works is by using runners to launch on-demand runners.
+  # Therefore, this usually isn't a bottleneck to scalability.
+  replicas: 1
+
   # The image to use for the installation.
   image:
     repository: "docker.io/hashicorp/waypoint"

--- a/values.yaml
+++ b/values.yaml
@@ -119,6 +119,15 @@ runner:
     # using the `waypoint server cookie` CLI command or the API.
     cookie: ""
 
+  # This configures the Statefulset to create a PVC for data storage for the
+  # runner. Runners do not require much data storage.
+  storage:
+    # Size of the PVC created
+    size: 1Gi
+    # Name of the storage class to use.  If null it will use the
+    # configured default Storage Class.
+    storageClass: null
+
   odr:
     # The image to use for the on-demand runner.
     image:

--- a/values.yaml
+++ b/values.yaml
@@ -106,6 +106,19 @@ runner:
   # Arguments to pass to the `waypoint runner agent` command. Will overwrite default options.
   agentArgs: ["-vvv"]
 
+  # Address to talk to the server with. If this is not specified, this will
+  # default to the server installed with this Helm chart release. If you're
+  # installing additional runners, you must specify this since additional runners
+  # are installed using Helm releases.
+  server:
+    addr: ""
+    tls: true
+    tlsSkipVerify: true
+
+    # Cookie must be specified for runner adoption. The cookie can be retrieved
+    # using the `waypoint server cookie` CLI command or the API.
+    cookie: ""
+
   odr:
     # The image to use for the on-demand runner.
     image:

--- a/values.yaml
+++ b/values.yaml
@@ -119,6 +119,11 @@ runner:
     # using the `waypoint server cookie` CLI command or the API.
     cookie: ""
 
+    # A secret to read the auth token from. This is optional. If this isn't
+    # set, runner adoption will be used. This only applies for runner-only
+    # installs. For server installs, the bootstrap token is used.
+    tokenSecret: ""
+
   # This configures the Statefulset to create a PVC for data storage for the
   # runner. Runners do not require much data storage.
   storage:


### PR DESCRIPTION
This enables a runner-only deployment, optionally with adoption. 

### Example: Adoption

```
$ helm install \
  --set server.enabled=false \
  --set runner.server.addr="1.2.3.4:5678" \
  --set runner.server.cookie="mycookie" \
  my-runner
  hashicorp/waypoint
```

### Example: Pre-Adoption from a Secret

```
$ helm install \
  --set server.enabled=false \
  --set runner.server.addr="1.2.3.4:5678" \
  --set runner.server.tokenSecret="mysecret" \
  my-runner
  hashicorp/waypoint
```

### Example: Adoption with Multiple Runners

```
$ helm install \
  --set server.enabled=false \
  --set runner.server.addr="1.2.3.4:5678" \
  --set runner.server.cookie="mycookie" \
  --set runner.replicas=2 \
  my-runner
  hashicorp/waypoint
```