### PR TITLE
Bump helm release version to v0.1.5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: waypoint
 description: Official Helm Chart for HashiCorp Waypoint
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.7.2"
 
 # We want Kube 1.20+ so that on-demand runners can be cleaned up properly.


### PR DESCRIPTION
Bumps the helm chart version to `v0.1.5` to go along with Waypoint 0.7.2 release update (#24). We'll create and push a `v0.1.5` tag after this is merged