### PR TITLE
feat: optional nodeSelector for runner and server statefulset

### DIFF
--- a/templates/runner-statefulset.yaml
+++ b/templates/runner-statefulset.yaml
@@ -150,4 +150,8 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+      {{- if .Values.runner.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.runner.nodeSelector . | indent 8 | trim }}
+      {{- end }}
 {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -100,6 +100,10 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+      {{- if .Values.server.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.server.nodeSelector . | indent 8 | trim }}
+      {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data-{{ .Release.Namespace }}

--- a/values.yaml
+++ b/values.yaml
@@ -62,6 +62,15 @@ server:
   # of the annotations to apply to the server pods
   annotations: {}
 
+  # nodeSelector labels for server pod assignment
+  # This should be formatted as a multi-line string.
+  # Example:
+  # ```yaml
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  # ```
+  nodeSelector: null
+
   # Definition of the serviceAccount used to run Waypoint.
   serviceAccount:
     # Specifies whether a service account should be created
@@ -183,17 +192,26 @@ runner:
     #    memory: 256Mi
     #    cpu: 250m
 
-  # Priority class for server pods
+  # Priority class for runner pods
   priorityClassName: ""
 
-  # Extra labels to attach to the server pods
-  # This should be a YAML map of the labels to apply to the server pods
+  # Extra labels to attach to the runner pods
+  # This should be a YAML map of the labels to apply to the runner pods
   extraLabels: {}
 
-  # Extra annotations to attach to the server pods
+  # Extra annotations to attach to the runner pods
   # This can either be YAML or a YAML-formatted multi-line templated string map
-  # of the annotations to apply to the server pods
+  # of the annotations to apply to the runner pods
   annotations: {}
+
+  # nodeSelector labels for runner pod assignment
+  # This should be formatted as a multi-line string.
+  # Example:
+  # ```yaml
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  # ```
+  nodeSelector: null
 
   # Definition of the serviceAccount used to by Waypoint static runner.
   # If using on-demand runners (enabled by default), this primarily


### PR DESCRIPTION
I wanted to use nodeSelectors in my setup.  I used the pattern from https://github.com/hashicorp/consul-helm.  I tested this in my environment and it worked as intended.

I could imagine a scenario where someone might want the bootstrap job to also run on specific nodes but I did not add that in the PR.  Could add if needed.

Also happy to close this PR if there's another way or if it's not relevant.