### PR TITLE
feat: service/ui - Allow YAML or multiline string for ui.service.annotations

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -236,3 +236,17 @@ Sets extra ingress annotations
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Sets extra UI Service annotations
+*/}}
+{{- define "waypoint.ui.service.annotations" -}}
+  {{- if .Values.ui.service.annotations }}
+    {{- $tp := typeOf .Values.ui.service.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.ui.service.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.ui.service.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     component: ui
   annotations:
-{{- template "waypoint.ui.service.annotations" . }}
+{{ template "waypoint.ui.service.annotations" . }}
 spec:
   selector:
     app.kubernetes.io/name: {{ template "waypoint.name" . }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -11,10 +11,8 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: ui
-  {{- if .Values.ui.service.annotations }}
   annotations:
-    {{ tpl .Values.ui.service.annotations . | nindent 4 | trim }}
-  {{- end }}
+{{- template "waypoint.ui.service.annotations" . }}
 spec:
   selector:
     app.kubernetes.io/name: {{ template "waypoint.name" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -227,7 +227,7 @@ ui:
     # @type: string
     type: LoadBalancer
 
-    # Extra annotations for the UI service. This can either be YAML or a
+    # Extra annotations for the UI Service. This can either be YAML or a
     # YAML-formatted multi-line templated string map of the annotations.
     annotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -227,16 +227,9 @@ ui:
     # @type: string
     type: LoadBalancer
 
-    # Annotations to apply to the UI service.
-    #
-    # Example:
-    #
-    # ```yaml
-    # annotations: |
-    #   'annotation-key': annotation-value
-    # ```
-    # @type: string
-    annotations: null
+    # Extra annotations for the UI service. This can either be YAML or a
+    # YAML-formatted multi-line templated string map of the annotations.
+    annotations: {}
 
     # Additional ServiceSpec values
     # This should be a multi-line string mapping directly to a Kubernetes

--- a/values.yaml
+++ b/values.yaml
@@ -228,7 +228,7 @@ ui:
     type: LoadBalancer
 
     # Extra annotations for the UI Service. This can either be YAML or a
-    # YAML-formatted multi-line templated string map of the annotations.
+    # YAML-formatted multi-line string map of the annotations.
     annotations: {}
 
     # Additional ServiceSpec values


### PR DESCRIPTION
First of all, thank you for putting together this Helm chart!

I ran into an inconsistency with `ui.service.annotations` compared to the [other annotations inputs](https://github.com/hashicorp/waypoint-helm/blob/6aeeef1674ce09ea6bcf8fe292fa5c588a3f1e24/values.yaml#L85-L89) in the chart. The `ui.service.annotations` input is the only one that requires a string input, while the others all account for string or YAML. It would be nice to have the annotation inputs consistent across components.

The issue:

```yaml
# values.yml
ui:
  service:
    annotations:
      foo: bar
```

> $ helm template .
...
 Error: template: waypoint/templates/ui-service.yaml:16:18: executing "waypoint/templates/ui-service.yaml" at <.Values.ui.service.annotations>: wrong type for value; expected string; got map[string]interface {}

The following cases have been manually tested and apply the following annotations

```yml
kind: Service
metadata:
  name: RELEASE-NAME-waypoint-ui
...
  annotations:
    foo: bar
```

From `values.yml` as yaml

```yml
ui:
  service:
    annotations:
      foo: bar
```

From `values.yml` as multi-line string

```yml
ui:
  service:
    annotations: |-
      foo: bar
```

From the CLI
```sh
helm template . --set ui.service.annotations.foo=bar
```
