### PR TITLE
feat: Add extra labels options to services

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -237,7 +237,6 @@ Sets extra ingress annotations
   {{- end }}
 {{- end -}}
 
-
 {{/*
 Formats extra labels using the passed labels value. Indentation should be handled by the caller.
 */}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -236,3 +236,17 @@ Sets extra ingress annotations
     {{- end }}
   {{- end }}
 {{- end -}}
+
+
+{{/*
+Formats extra labels using the passed labels value. Indentation should be handled by the caller.
+*/}}
+{{- define "waypoint.extraLabels" -}}
+{{- with . }}
+  {{- if typeOf . | eq "string" }}
+    {{- . }}
+  {{- else }}
+    {{- toYaml . }}
+  {{- end}}
+{{- end }}
+{{- end }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -11,9 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ include "waypoint.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- with .Values.ui.ingress.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "waypoint.extraLabels" .Values.ui.ingress.labels | nindent 4 }}
   annotations:
     alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/name: {{ include "waypoint.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "waypoint.extraLabels" .Values.server.service.labels | nindent 4 }}
   annotations:
 {{ template "waypoint.service.annotations" .}}
 spec:

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -11,6 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     component: ui
+    {{- include "waypoint.extraLabels" .Values.ui.service.labels | nindent 4 }}
   {{- if .Values.ui.service.annotations }}
   annotations:
     {{ tpl .Values.ui.service.annotations . | nindent 4 | trim }}

--- a/values.yaml
+++ b/values.yaml
@@ -88,6 +88,9 @@ server:
     # to the service.
     annotations: {}
 
+    # Extra labels for the server service definition, passed as YAML or a string
+    labels: {}
+
 runner:
   # If not set to true, the Waypoint runner will not be installed. At least
   # one static runner must exist in a Waypoint cluster for on-demand runners
@@ -238,6 +241,9 @@ ui:
     # @type: string
     annotations: null
 
+    # Extra labels for the UI service definition, passed as YAML or a string
+    labels: {}
+
     # Additional ServiceSpec values
     # This should be a multi-line string mapping directly to a Kubernetes
     # ServiceSpec object.
@@ -257,6 +263,7 @@ ui:
       - host: chart-example.local
         paths: []
 
+    # Extra labels for the UI ingress definition, passed as YAML or a string
     labels: {}
       # traffic: external
 


### PR DESCRIPTION
Adds the option to pass extra labels to `ui.service` or the `server.service`.

Our use case is that we use [external-dns](https://github.com/kubernetes-sigs/external-dns) to create DNS records for our Service and Ingress resources. Our `external-dns` deployment uses a [label filter](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md#running-an-internal-and-external-dns-service) to determine whether it should create a DNS record for that resource or not. For our Waypoint installation, we are using the UI Service to create a load balancer as our point of ingress, so it would be ideal for us if we could also add a label to that Service which would allow our `external-dns` deployment to create a DNS record for that load balancer.

Tests:

Via CLI using --set
```sh
$ helm template . --set ui.service.labels="foo: bar"
# Source: waypoint/templates/ui-service.yaml
metadata:
  labels:
    ...
    foo: bar
```

Via values.yml as YAML
```
# extra-values.yml
server:
  service:
    labels:
      foo: bar
ui:
  service:
    labels:
      baz: woz
  ingress:
    enabled: true
    labels:
      traffic: external

$ helm template . --values extra-values.yml

# Source: waypoint/templates/server-service.yaml
metadata:
  labels:
    ...
    foo: bar
---
# Source: waypoint/templates/ui-service.yaml
metadata:  
  labels:
    ...
    baz: woz
---
# Source: waypoint/templates/server-ingress.yaml
...
metadata:
  labels:
    ...
    traffic: external
```

Via values.yml as string
```
# extra-values.yml
server:
  service:
    labels: |-
      foo: bar
ui:
  service:
    labels: |-
      baz: woz
  ingress:
    enabled: true
    labels: |-
      traffic: external

$ helm template . --values extra-values.yml

# Source: waypoint/templates/server-service.yaml
metadata:
  labels:
    ...
    foo: bar
---
# Source: waypoint/templates/ui-service.yaml
metadata:  
  labels:
    ...
    baz: woz
---
# Source: waypoint/templates/server-ingress.yaml
...
metadata:
  labels:
    ...
    traffic: external
```
```
