### PR TITLE
Add unique name to bootstrap jobs

### DIFF
--- a/templates/bootstrap-job.yaml
+++ b/templates/bootstrap-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "waypoint.fullname" . }}-bootstrap-{{ randAlphaNum 6 | nospace | lower }}
+  name: {{ template "waypoint.fullname" . }}-bootstrap-{{ .Values.server.image.tag | default "latest" }}-{{ randAlphaNum 6 | nospace | lower }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "waypoint.name" . }}

--- a/templates/bootstrap-job.yaml
+++ b/templates/bootstrap-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "waypoint.fullname" . }}-bootstrap
+  name: {{ template "waypoint.fullname" . }}-bootstrap-{{ randAlphaNum 6 | nospace }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "waypoint.name" . }}

--- a/templates/bootstrap-job.yaml
+++ b/templates/bootstrap-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "waypoint.fullname" . }}-bootstrap-{{ randAlphaNum 6 | nospace }}
+  name: {{ template "waypoint.fullname" . }}-bootstrap-{{ randAlphaNum 6 | nospace | lower }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "waypoint.name" . }}


### PR DESCRIPTION
Prior to this, upgrades would fail attempting to modify the spec.template of the bootstrap job. Job templates in kubernetes are immutable.

The workaround here is to add a random string to the job name, creating a new job per `helm install`. This has the downside of leaving around jobs from previous installations.

Example pod name after this change:

```
$ kubectl get jobs
NAME                              COMPLETIONS   DURATION   AGE
waypoint-bootstrap-0.8.2-acdcig   0/1           2s         2s
```
