### PR TITLE
Add an ability to define toleration for Server and Runner StatefulSets

### DIFF
--- a/templates/runner-statefulset.yaml
+++ b/templates/runner-statefulset.yaml
@@ -147,4 +147,8 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+      {{- if .Values.runner.tolerations}}
+      tolerations:
+      {{- toYaml .Values.runner.tolerations | nindent 8  }}
+      {{- end}}
 {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -100,6 +100,10 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+      {{- if .Values.runner.tolerations}}
+      tolerations:
+      {{- toYaml .Values.runner.tolerations | nindent 8 }}
+      {{- end}}
   volumeClaimTemplates:
     - metadata:
         name: data-{{ .Release.Namespace }}

--- a/values.yaml
+++ b/values.yaml
@@ -195,6 +195,9 @@ runner:
   # of the annotations to apply to the server pods
   annotations: {}
 
+  # Toleration settings for runner
+  tolerations: []
+
   # Definition of the serviceAccount used to by Waypoint static runner.
   # If using on-demand runners (enabled by default), this primarily
   # needs permissions to run tasks.


### PR DESCRIPTION
Add support to define tolerations for server and runner.

Fixes: https://github.com/hashicorp/waypoint-helm/issues/42