### PR TITLE
Increase runner liveness probe failure threshold

### DIFF
--- a/templates/runner-statefulset.yaml
+++ b/templates/runner-statefulset.yaml
@@ -142,7 +142,7 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 1234
-            failureThreshold: 2
+            failureThreshold: 10
             initialDelaySeconds: 5
             periodSeconds: 3
             successThreshold: 1


### PR DESCRIPTION
## What problem does this address?

Lets say a user runs the following command:

```
waypoint runner install -platform=kubernetes -server-addr=10.0.0.10:9711 -server-tls=false
```

But `10.0.0.10` is the wrong address.

What currently happens is that the runner attempts to connect, but it's killed by kubernetes due to not passing liveness before it can report a context deadline exceeded error. It doesn't log anything - it just crashloops. This gives the user no indication as to what the problem could be.

## How does this fix it?

With this change, kubernetes won't kill the pod until after the client's default connection timeout window has passed, giving the runner a chance to log the fact that it couldn't reach the server.