### PR TITLE
Adding bootstrap annotations

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -213,6 +213,22 @@ Sets extra service account annotations
 {{- end -}}
 
 {{/*
+Sets extra bootstrap annotations
+*/}}
+{{- define "waypoint.bootstrap.annotations" -}}
+  {{- if .Values.bootstrap.annotations }}
+      annotations:
+        {{- $tp := typeOf .Values.bootstrap.annotations }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.bootstrap.annotations . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.bootstrap.annotations | nindent 8 }}
+        {{- end }}
+  {{- end }}
+{{- end -}}
+
+
+{{/*
 imagePullSecrets generates pull secrets from either string or map values.
 A map value must be indexable by the key 'name'.
 */}}

--- a/templates/bootstrap-job.yaml
+++ b/templates/bootstrap-job.yaml
@@ -21,7 +21,8 @@ spec:
         app.kubernetes.io/name: {{ template "waypoint.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: bootstrap
-      {{ template "waypoint.annotations" . }}
+      {{ template "waypoint.bootstrap.annotations" . }}
+
     spec:
       serviceAccountName: {{ template "waypoint.bootstrap.serviceAccount.name" . }}
       restartPolicy: Never

--- a/templates/bootstrap-job.yaml
+++ b/templates/bootstrap-job.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/name: {{ template "waypoint.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: bootstrap
+      {{ template "waypoint.annotations" . }}
     spec:
       serviceAccountName: {{ template "waypoint.bootstrap.serviceAccount.name" . }}
       restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -304,6 +304,10 @@ ui:
     #      - chart-example.local
 
 bootstrap:
+  # Extra annotations for the bootstrap job definition. This can either be
+  # YAML or a YAML-formatted multi-line templated string map of the
+  # annotations to apply to the pod template of the bootstrap job.
+  annotations: {}
   # Definition of the serviceAccount used to bootstrap Waypoint.
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
Till now it was not possible to add any pod template annotations for the bootstrap job process. This could lead into some issues in some environments that injects sidecars by default except, that can be avoided with a `false` value annotation that is in the pod metadata (e.g. Consul annotation `"consul.hashicorp.com/connect-inject": "false"`).

This PR adds in the template a `bootstrap.annotations` for the `values.yaml` to add annotations in the Waypoint bootstrapping pod.