### PR TITLE
update how we render these templates to fix up usage of . and $

### DIFF
--- a/templates/runner-rolebinding.yaml
+++ b/templates/runner-rolebinding.yaml
@@ -14,20 +14,20 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "waypoint.fullname" . }}-runner-rolebinding
+  name: {{ template "waypoint.fullname" $ }}-runner-rolebinding
   namespace: {{ . }}
   labels:
-    app.kubernetes.io/name: {{ include "waypoint.name" . }}-runner
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "waypoint.name" $ }}-runner
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
 roleRef:
   apiGroup: ""
   kind: ClusterRole
   name: edit
 subjects:
   - kind: ServiceAccount
-    name: {{ template "waypoint.runner.serviceAccount.name" . }}
-    namespace: {{ .Release.Namespace }}
+    name: {{ template "waypoint.runner.serviceAccount.name" $ }}
+    namespace: {{ $.Release.Namespace }}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
**NOTE:** This pr is opened against a WIP branch, not against `main`

Fix up the rolebinding template rendering now that it loops. We need to use `$` instead of `.` as `.` takes a different meaning inside the loop.

