### PR TITLE
Call helm publish workflow by file name without path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: update helm-charts index
           command: |
             export GITHUB_TOKEN="${HELM_CHARTS_GITHUB_TOKEN}"
-            ./bin/gh workflow run .github/workflows/publish-charts.yml \
+            ./bin/gh workflow run publish-charts.yml \
               --repo hashicorp/helm-charts \
               --ref main \
               -f SOURCE_TAG="${CIRCLE_TAG}" \


### PR DESCRIPTION
Background for this change can be seen in https://github.com/hashicorp/crt-workflows-common/pull/274